### PR TITLE
ci: Verify external installation on main

### DIFF
--- a/.github/workflows/ci_ubuntu_verify_external_installation.yml
+++ b/.github/workflows/ci_ubuntu_verify_external_installation.yml
@@ -12,15 +12,15 @@ jobs:
       cm_versions: ${{ steps.extract-versions.outputs.cm_versions }}
     steps:
       - name: Install maintainer publickey
-        run: curl -s --compressed https://vorausrobotik.github.io/wibu-packages/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
+        run: curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
       - name: Add local repo to APT sources
-        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://vorausrobotik.github.io/wibu-packages/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
+        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://wibu-packages.vorausrobotik.com/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
       - name: update apt
         run: sudo apt-get update
       - name: Get available versions of c-lite
         id: get_versions
         run: |
-          apt-cache madison codemeter-lite | grep "https://vorausrobotik.github.io/wibu-packages/ubuntu" | awk '{print $3}' > versions.txt
+          apt-cache madison codemeter-lite | grep "https://wibu-packages.vorausrobotik.com/ubuntu" | awk '{print $3}' > versions.txt
           cat versions.txt
       - name: Extract lines from versions.txt
         id: extract-versions
@@ -35,9 +35,9 @@ jobs:
         version: ${{ fromJson(needs.fetch_installations.outputs.cm_versions) }}
     steps:
       - name: Install maintainer publickey
-        run: curl -s --compressed https://vorausrobotik.github.io/wibu-packages/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
+        run: curl -s --compressed https://wibu-packages.vorausrobotik.com/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
       - name: Add local repo to APT sources
-        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://vorausrobotik.github.io/wibu-packages/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
+        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://wibu-packages.vorausrobotik.com/wibu-packages/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
       - name: Update apt
         run: sudo apt-get update
       - name: Install codemeter-lite in version ${{ matrix.version }}

--- a/.github/workflows/ci_ubuntu_verify_external_installation.yml
+++ b/.github/workflows/ci_ubuntu_verify_external_installation.yml
@@ -3,6 +3,8 @@ name: CI ubuntu verify external installation
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 * * * *'
 jobs:
   fetch_installations_externally:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_ubuntu_verify_external_installation.yml
+++ b/.github/workflows/ci_ubuntu_verify_external_installation.yml
@@ -1,0 +1,48 @@
+name: CI ubuntu verify external installation
+'on':
+  push:
+    branches:
+      - main
+jobs:
+  fetch_installations_externally:
+    runs-on: ubuntu-latest
+    outputs:
+      cm_versions: ${{ steps.extract-versions.outputs.cm_versions }}
+    steps:
+      - name: Install maintainer publickey
+        run: curl -s --compressed https://vorausrobotik.github.io/wibu-packages/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
+      - name: Add local repo to APT sources
+        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://vorausrobotik.github.io/wibu-packages/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
+      - name: update apt
+        run: sudo apt-get update
+      - name: Get available versions of c-lite
+        id: get_versions
+        run: |
+          apt-cache madison codemeter-lite | grep "https://vorausrobotik.github.io/wibu-packages/ubuntu" | awk '{print $3}' > versions.txt
+          cat versions.txt
+      - name: Extract lines from versions.txt
+        id: extract-versions
+        run: |
+          versions=$(cat versions.txt | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "cm_versions=$versions" >> $GITHUB_OUTPUT
+  package_is_installable_externally:
+    runs-on: ubuntu-latest
+    needs: fetch_installations
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.fetch_installations.outputs.cm_versions) }}
+    steps:
+      - name: Install maintainer publickey
+        run: curl -s --compressed https://vorausrobotik.github.io/wibu-packages/ubuntu/burfeind_jan-niklas.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg
+      - name: Add local repo to APT sources
+        run: echo "deb [signed-by=/etc/apt/trusted.gpg.d/burfeind_jan-niklas.gpg] https://vorausrobotik.github.io/wibu-packages/ubuntu/ ./" | sudo tee /etc/apt/sources.list.d/voraus-wibu.list
+      - name: Update apt
+        run: sudo apt-get update
+      - name: Install codemeter-lite in version ${{ matrix.version }}
+        run: sudo apt-get install -y codemeter-lite=${{ matrix.version }}
+      - name: Codemeter is running
+        run: systemctl status codemeter
+      - name: Codemeter version output is expected
+        run: cmu --version | grep -q '${{ matrix.version }}'
+      - name: Verify codemeter service is running as daemon user
+        run: systemctl show -pUser codemeter.service | grep -qx User=daemon


### PR DESCRIPTION
The alternative would be to provide github pages for all branches, which would allow PR openers to directly host content, which is ill advised imho.