### PR TITLE
chore: Remove team ranger from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @AiyionPrime @philipp-caspers @DS424 @tobiasbrinker
+* @AiyionPrime


### PR DESCRIPTION
> following the restructurization in october "24.